### PR TITLE
Change color scheme to match logo and distinguish from Tartu 2024

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -344,43 +344,43 @@ popupTemplateSuffix = "</ul>"
 type = "fa"
 name = "venue"
 icon = "building-columns"
-markerColor = "#f06a36"
+markerColor = "#4e9790"
 
 [[params.map.icon]]
 type = "fa"
 name = "social"
 icon = "user-group"
-markerColor = "#f06a36"
+markerColor = "#4e9790"
 
 [[params.map.icon]]
 type = "fa"
 name = "pubcrawl"
 icon = "martini-glass-empty"
-markerColor = "#f06a36"
+markerColor = "#4e9790"
 
 [[params.map.icon]]
 type = "fa"
 name = "airport"
 icon = "plane-departure"
-markerColor = "#f06a36"
+markerColor = "#4e9790"
 
 [[params.map.icon]]
 type = "fa"
 name = "bus"
 icon = "bus"
-markerColor = "#f06a36"
+markerColor = "#4e9790"
 
 [[params.map.icon]]
 type = "fa"
 name = "train"
 icon = "train"
-markerColor = "#f06a36"
+markerColor = "#4e9790"
 
 [[params.map.icon]]
 type = "fa"
 name = "familyfirendly"
 icon = "child-reaching"
-markerColor = "#f06a36"
+markerColor = "#4e9790"
 
 # [[params.map.layer]]
 # id = 1

--- a/themes/eventre-hugo/assets/scss/_common.scss
+++ b/themes/eventre-hugo/assets/scss/_common.scss
@@ -33,14 +33,8 @@
 
   &:after {
     content: "";
-    background: -webkit-linear-gradient(
-      -45deg,
-      #1e5799 0%,
-      #1d1546 0%,
-      #1a0b25 100%,
-      #207cca 100%
-    );
-    opacity: 0.6;
+    background: -webkit-linear-gradient(45deg, #000000 0%, #000000 0%, #000000 100%, #000000 100%);
+    opacity: 0.61;
     position: absolute;
     top: 0;
     left: 0;
@@ -52,13 +46,11 @@
 .overlay-lighter {
   &:before {
     content: "";
-    background: -webkit-linear-gradient(
-      -45deg,
-      #1e5799 0%,
-      #1d1546 0%,
-      #1a0b25 100%,
-      #207cca 100%
-    );
+    background: -webkit-linear-gradient(-45deg,
+        #828486 0%,
+        #040309 0%,
+        #1a0b25 100%,
+        #787878 100%);
     opacity: 0.2;
     position: absolute;
     top: 0;
@@ -108,14 +100,8 @@
 .overlay-dark {
   &:before {
     content: "";
-    background: -webkit-linear-gradient(
-      -45deg,
-      #1e5799 0%,
-      #1d1546 0%,
-      #1a0b25 100%,
-      #207cca 100%
-    );
-    opacity: 0.75;
+    background: -webkit-linear-gradient(-45deg, #ffffff 0%, #000000 0%, #000000 100%, #ffffff 100%);
+    opacity: 0.65;
     position: absolute;
     top: 0;
     left: 0;
@@ -127,11 +113,9 @@
 .overlay-white {
   &:before {
     content: "";
-    background: linear-gradient(
-      0deg,
-      rgba(245, 245, 248, 0.8) 0%,
-      rgba(247, 247, 247, 1) 100%
-    );
+    background: linear-gradient(0deg,
+        rgba(245, 245, 248, 0.8) 0%,
+        rgba(247, 247, 247, 1) 100%);
     position: absolute;
     top: 0;
     left: 0;
@@ -295,12 +279,12 @@ button {
     margin-bottom: 20px;
   }
 
-  p {
-  }
+  p {}
 
   margin-bottom: 40px;
 
   &.white {
+
     h3,
     p {
       color: $light;
@@ -518,7 +502,7 @@ select.form-control:not([size]):not([multiple]) {
   padding: 10px 20px 10px 20px;
   border: 1px solid #fff;
 
-  &:hover{
+  &:hover {
     border-color: $primary-color;
   }
 }

--- a/themes/eventre-hugo/assets/scss/_typography.scss
+++ b/themes/eventre-hugo/assets/scss/_typography.scss
@@ -1,47 +1,58 @@
 // Google Font Import
 @import url('https://fonts.googleapis.com/css?family=Montserrat:300,400,500,600,700|Roboto:300,400,500,700');
+
 // font size
 html {
 	font-size: 16px;
 }
+
 // Body
-body{
+body {
 	font-family: $primary-font;
 	-webkit-font-smoothing: antialiased;
 }
 
 // Headings
-h1,h2,h3,h4,h5,h6{
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
 	font-family: $secondary-font;
 	color: $black;
 	font-weight: 600;
 }
 
-h1{
+h1 {
 	font-size: 2.8rem; //45px
 }
 
-h2{
+h2 {
 	font-size: 2.5rem; //40px
 }
 
-h3{
+h3 {
 	font-size: 2.25rem; //36px
 }
 
-h4{
-	font-size: 1.6875rem;//27px
+h4 {
+	font-size: 1.6875rem; //27px
 }
 
-h5{
+h5 {
 	font-size: 1.375rem; //22px
 }
 
-h6{
+h6 {
 	font-size: 1.25rem; //20px
 }
+
 // Others
-p, li, blockquote, label{
+p,
+li,
+blockquote,
+label {
 	font-size: 1rem;
 	line-height: 26px;
 	color: black;
@@ -51,8 +62,9 @@ p, li, blockquote, label{
 a {
 	font-size: 1rem;
 	line-height: 26px;
-	color: #ef6530;
+	color: #4e9790;
 	margin-bottom: 0;
+
 	&:hover {
 		color: ee581e;
 	}
@@ -61,6 +73,6 @@ a {
 
 // Placeholder Color Change
 .form-control::-webkit-input-placeholder {
-    color: darken($light, 30%);
-    font-size: 0.9375rem;//15px
- }
+	color: darken($light, 30%);
+	font-size: 0.9375rem; //15px
+}

--- a/themes/eventre-hugo/assets/scss/_variables.scss
+++ b/themes/eventre-hugo/assets/scss/_variables.scss
@@ -1,8 +1,8 @@
 // Variables
 $body-color: #ffffff;
-$primary-color: #f06a36;
+$primary-color: #4e9790;
 $secondary-color: #485c72;
-$border-color:#e5e5e5;
+$border-color: #e5e5e5;
 $primary-font: 'Roboto', sans-serif;
 $secondary-font: 'Montserrat', sans-serif;
 $text-color: #848484;

--- a/themes/eventre-hugo/assets/scss/_variables.scss
+++ b/themes/eventre-hugo/assets/scss/_variables.scss
@@ -1,6 +1,7 @@
 // Variables
 $body-color: #ffffff;
 $primary-color: #4e9790;
+$primary-color-highlight: #88ccc5;
 $secondary-color: #485c72;
 $border-color: #e5e5e5;
 $primary-font: 'Roboto', sans-serif;

--- a/themes/eventre-hugo/assets/scss/components/_footer.scss
+++ b/themes/eventre-hugo/assets/scss/components/_footer.scss
@@ -1,12 +1,19 @@
 .footer-main {
-  background: #272735;
-  padding: 90px 0;
+  background: #1f2221;
+  padding-top: 60px;
 
   @include tablet {
     padding: 50px 0;
   }
 
   .block {
+    .navbar-brand {
+      .img-fluid {
+        border: solid 5px white;
+        border-radius: 2px;
+      }
+    }
+
     img {
       margin-bottom: 60px;
     }
@@ -49,7 +56,7 @@
 }
 
 .subfooter {
-  background: #2a2a37;
+  background: #1f2221;
   padding: 18px 0;
 
   .copyright-text {
@@ -58,7 +65,8 @@
       color: $light;
 
       a {
-        color: $primary-color;
+        color: $primary-color-highlight;
+        text-shadow: 3.5px 6.062px 0px rgba(0, 0, 0, 0.22);
       }
     }
 

--- a/themes/eventre-hugo/assets/scss/components/_footer.scss
+++ b/themes/eventre-hugo/assets/scss/components/_footer.scss
@@ -1,9 +1,11 @@
 .footer-main {
   background: #272735;
   padding: 90px 0;
+
   @include tablet {
     padding: 50px 0;
   }
+
   .block {
     img {
       margin-bottom: 60px;
@@ -11,12 +13,15 @@
 
     ul.social-links-footer {
       margin-bottom: 0;
+
       .list-inline-item:not(:last-child) {
         margin-right: 20px;
+
         @include mobile {
           margin-right: 5px;
         }
       }
+
       li {
         a {
           display: block;
@@ -24,12 +29,15 @@
           width: 50px;
           text-align: center;
           background: $light;
+
           i {
             line-height: 50px;
             color: #44586e;
           }
+
           &:hover {
             background: $primary-color;
+
             i {
               color: $light;
             }
@@ -43,17 +51,22 @@
 .subfooter {
   background: #2a2a37;
   padding: 18px 0;
+
   .copyright-text {
     p {
       font-family: $secondary-font;
+      color: $light;
+
       a {
         color: $primary-color;
       }
     }
+
     @include tablet {
       text-align: center;
     }
   }
+
   .to-top {
     display: block;
     height: 45px;
@@ -61,11 +74,13 @@
     text-align: center;
     background: $primary-color;
     float: right;
+
     i {
       font-size: 1.5rem;
       color: $light;
       line-height: 45px;
     }
+
     @include tablet {
       float: none;
       margin: auto;

--- a/themes/eventre-hugo/assets/scss/components/_navigation.scss
+++ b/themes/eventre-hugo/assets/scss/components/_navigation.scss
@@ -1,23 +1,29 @@
-.main-nav{
+.main-nav {
 	background: $light;
-	@include tablet{
+
+	@include tablet {
 		position: relative;
 	}
-	.navbar-brand{
+
+	.navbar-brand {
 		padding: 35px 40px 35px 50px;
 		border-right: 1px solid $border-color;
+
 		@include large-desktop {
 			padding: 20px 30px;
 		}
+
 		@include tablet {
 			border-right: none;
 		}
 	}
-	.navbar-nav{
-		.nav-item{
+
+	.navbar-nav {
+		.nav-item {
 			position: relative;
 			font-family: $primary-font;
-			.nav-link{
+
+			.nav-link {
 				position: relative;
 				text-align: center;
 				color: $black;
@@ -25,112 +31,137 @@
 				padding-right: 20px;
 				font-size: 1.06rem;
 				font-family: $secondary-font;
+
 				@include desktop-nav {
 					font-size: 0.75rem;
 					padding-left: 5px;
 					padding-right: 10px;
 				}
-				@include large-desktop{
-				}
-				span{
+
+				@include large-desktop {}
+
+				span {
 					color: $black;
 					margin-left: 20px;
+
 					@include desktop {
 						margin-left: 10px;
 					}
 				}
 			}
-			&.active{
-				.nav-link{
+
+			&.active {
+				.nav-link {
 					color: $primary-color;
 				}
 			}
 		}
 	}
+
 	.dropdown-slide {
-	  position: static;
-	  .open>a, .open>a:focus, .open>a:hover {
-	    background: transparent;
+		position: static;
+
+		.open>a,
+		.open>a:focus,
+		.open>a:hover {
+			background: transparent;
 		}
-	  &.full-width {
-	    .dropdown-menu {
-	      left:0!important;
-	      right:0!important;
-	    }
-	  }
-	  &:hover .dropdown-menu {
-	  	border-top: 3px solid $primary-color;
-	    display:none;
-	    opacity: 1;
-	    display: block;
-	    transform: translate(0px ,0px);
-	    opacity: 1;
-	    visibility: visible;
-	    color: #777;
-	    transform: translateY(0px);
-	  }
-	  .dropdown-menu {
-	  	min-width: 220px;
-	  	.dropdown-item{
-	  		font-size: 15px;
-  		    padding: 10px 0;
-  		    transition: .3s ease;
-  		    &:not(:last-child){
-  		    	border-bottom: 1px solid $border-color;
-  		    }
-  		    &:hover{
-  		    	background: $light;
-  		    	color: $primary-color;
-  		    }
-	  	}
-	  	margin-top: 0;
-	    border-radius:0;
-	    opacity: 1;
-	    visibility: visible;
-	    position: absolute;
-	    padding: 5px 15px;
-	    border: 1px solid #ebebeb;
-	    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-	    transition:.3s all;
-	    position: absolute;
-	    display: block;
-	    visibility: hidden;
-	    opacity: 0;
-	    transform: translateY(30px);
-			transition: visibility 0.2s, opacity 0.2s, transform 500ms cubic-bezier(0.43, 0.26, 0.11, 0.99);
+
+		&.full-width {
+			.dropdown-menu {
+				left: 0 !important;
+				right: 0 !important;
+			}
+		}
+
+		&:hover .dropdown-menu {
+			border-top: 3px solid $primary-color;
+			display: none;
+			opacity: 1;
+			display: block;
+			transform: translate(0px, 0px);
+			opacity: 1;
+			visibility: visible;
+			color: #777;
+			transform: translateY(0px);
+		}
+
+		.dropdown-menu {
+			min-width: 220px;
+
+			.dropdown-item {
+				font-size: 15px;
+				padding: 10px 0;
+				transition: .3s ease;
+
+				&:not(:last-child) {
+					border-bottom: 1px solid $border-color;
+				}
+
+				&:hover {
+					background: $light;
+					color: $primary-color;
+				}
+			}
+
+			margin-top: 0;
+			border-radius:0;
+			opacity: 1;
+			visibility: visible;
+			position: absolute;
+			padding: 5px 15px;
+			border: 1px solid #ebebeb;
+			box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+			transition:.3s all;
+			position: absolute;
+			display: block;
+			visibility: hidden;
+			opacity: 0;
+			transform: translateY(30px);
+			transition: visibility 0.2s,
+			opacity 0.2s,
+			transform 500ms cubic-bezier(0.43, 0.26, 0.11, 0.99);
+
 			@include desktop-sm {
 				transform: none;
-		    left: auto;
-		    position: relative;
+				left: auto;
+				position: relative;
 				text-align: center;
 				opacity: 1;
 				visibility: visible;
-	    }
-	  }
+			}
+		}
 	}
-	.ticket{
+
+	.ticket {
 		background: $primary-color;
 		display: block;
 		padding: 34px 32px;
+
 		@include large-desktop {
 			padding: 23px 14px;
 		}
-		@include desktop-sm{
+
+		@include desktop-sm {
 			text-align: center;
 		}
-		img{
+
+		img {
 			margin-right: 25px;
+
 			@include large-desktop {
 				display: none;
 			}
 		}
-		span{
+
+		span {
 			color: $light;
 			font-size: 1.125rem;
 			text-transform: uppercase;
 			font-family: $secondary-font;
 			border-left: 1px solid #ffa366;
 			padding-left: 24px;
+
 			@include large-desktop {
 				padding-left: 0;
 				font-size: 1rem;
@@ -141,7 +172,8 @@
 }
 
 // bootstrap override
-.navbar-toggler:focus, .navbar-toggler:hover{
+.navbar-toggler:focus,
+.navbar-toggler:hover {
 	outline: none;
 }
 

--- a/themes/eventre-hugo/assets/scss/pages/_home.scss
+++ b/themes/eventre-hugo/assets/scss/pages/_home.scss
@@ -1,83 +1,99 @@
 // Banner Styles
-.banner{
+.banner {
 	padding: 250px 0 150px;
 	position: relative;
+
 	@include desktop {
 		padding: 100px 0;
 	}
-	.block{
+
+	.block {
 		position: relative;
 		z-index: 10;
-		.timer{
+
+		.timer {
 			.syotimer-cell {
-		        margin-right: 25px;
-		        margin-bottom: 33px;
-		        display:inline-block;
-		        @include mobile {
-		        	margin-right: 10px;
-		        	margin-bottom: 20px;
-		        }
-		        .syotimer-cell__value {
-		        	min-width: 80px;
-		        	font-family: $secondary-font;
+				margin-right: 25px;
+				margin-bottom: 33px;
+				display: inline-block;
+
+				@include mobile {
+					margin-right: 10px;
+					margin-bottom: 20px;
+				}
+
+				.syotimer-cell__value {
+					min-width: 80px;
+					font-family: $secondary-font;
 					font-size: 35px;
 					line-height: 77px;
 					text-align: center;
 					position: relative;
 					font-weight: bold;
 					color: $light;
-					border: 2px solid #7c7491;
+					border: 2px solid #beae9c;
 					margin-bottom: 8px;
 					border-radius: 100%;
-			        box-shadow: 3.5px 6.062px 0px 0px rgba(0, 0, 0, 0.1);
-			        @include mobile {
-			        	font-size: 30px;
+					box-shadow: 3.5px 6.062px 0px 0px rgba(0, 0, 0, 0.1);
+
+					@include mobile {
+						font-size: 30px;
 					}
-					@include mobile-xs{
+
+					@include mobile-xs {
 						min-width: 65px;
 						line-height: 61px;
 						font-size: 25px;
 					}
-		        }
-		        .syotimer-cell__unit {
-		        	text-align: center;
+				}
+
+				.syotimer-cell__unit {
+					text-align: center;
 					font-size: 1rem;
 					text-transform: lowercase;
-					font-weight:normal;
+					font-weight: normal;
 					color: $light;
 					font-family: $secondary-font;
-		        }
-		      }
+				}
+			}
 		}
-		h1{
+
+		h1 {
 			text-transform: uppercase;
 			font-size: 5.5rem;
-			color: $primary-color;
+			color: $primary-color-highlight;
 			font-weight: 500;
 			margin-bottom: 5px;
+
 			@include tablet {
 				font-size: 4rem;
 			}
-			@include mobile-xs{
+
+			@include mobile-xs {
 				font-size: 3rem;
 			}
-	        text-shadow: 3.5px 6.062px 0px rgba(0, 0, 0, 0.1);
+
+			text-shadow: 3.5px 6.062px 0px rgba(0, 0, 0, 0.25);
 		}
-		h2{
+
+		h2 {
 			text-transform: uppercase;
 			font-size: 4.625rem;
 			color: $light;
 			font-weight: 400;
-	        text-shadow: 3.5px 6.062px 0px rgba(0, 0, 0, 0.1);
+			text-shadow: 3.5px 6.062px 0px rgba(0, 0, 0, 0.1);
 			font-style: italic;
+
 			@include tablet {
 				font-size: 3.2rem;
 			}
-			@include mobile-xs{
+
+			@include mobile-xs {
 				font-size: 2.3rem;
 			}
 		}
-		h6{
+
+		h6 {
 			color: $light;
 			font-weight: 400;
 			margin-bottom: 50px;
@@ -85,38 +101,46 @@
 	}
 }
 
-.banner-two{
+.banner-two {
 	padding: 250px 0 150px;
 	position: relative;
 	overflow: hidden;
-	.block{
-		h1{
+
+	.block {
+		h1 {
 			color: $primary-color;
 			font-size: 88px;
-			@include mobile{
+
+			@include mobile {
 				font-size: 40px;
 			}
 		}
-		h2{
+
+		h2 {
 			font-weight: 400;
 			text-transform: uppercase;
 			font-size: 74px;
 			margin-bottom: 10px;
-			@include mobile{
+
+			@include mobile {
 				font-size: 35px;
 			}
 		}
-		h3{
+
+		h3 {
 			font-size: 74px;
-			@include mobile{
+
+			@include mobile {
 				font-size: 35px;
 			}
 		}
-		h6{
+
+		h6 {
 			margin-top: 48px;
 			font-weight: 400;
 			margin-bottom: 60px;
-			@include mobile{
+
+			@include mobile {
 				margin-top: 30px;
 			}
 		}
@@ -124,104 +148,128 @@
 }
 
 .about {
-	.image-block{
+	.image-block {
 		padding: 30px;
-		img{
+
+		img {
 			border-radius: 5%;
 			box-shadow: 0px 0px 59px 0px rgba(11, 29, 66, 0.15);
 		}
+
 		@include tablet {
 			margin-bottom: 30px;
 			text-align: center;
 		}
-		&.two{
+
+		&.two {
 			padding: 0;
 			margin-top: 30px;
-			img{
+
+			img {
 				border-radius: 0;
 				transform: translate(30px, -30px);
-				@include tablet{
+
+				@include tablet {
 					transform: translate(0, -30px);
 				}
 			}
 		}
 	}
-	.content-block{
+
+	.content-block {
 		margin-left: 15px;
+
 		@include tablet {
 			text-align: center;
 		}
-		h2{
-			&:after{
+
+		h2 {
+			&:after {
 				content: "";
 				width: 60px;
 				height: 3px;
 				background: $primary-color;
 				display: block;
 				margin-top: 10px;
+
 				@include tablet {
 					margin: auto;
 				}
 			}
+
 			margin-bottom: 35px;
 		}
-		.description-one{
-			p{
+
+		.description-one {
+			p {
 				color: $black;
 				font-size: 1.0625rem;
 			}
+
 			margin-bottom: 20px;
 		}
-		.description-two{
-			p{
+
+		.description-two {
+			p {
 				font-size: 0.9375em;
 			}
+
 			margin-bottom: 30px;
 		}
-		ul.list-inline{
-			.list-inline-item{
-				@include mobile{
+
+		ul.list-inline {
+			.list-inline-item {
+				@include mobile {
 					display: block;
 				}
 			}
 		}
+
 		.list-inline-item:not(:last-child) {
-		    margin-right: 20px;
-		    @include desktop-sm {
-		    	margin-bottom: 10px;
+			margin-right: 20px;
+
+			@include desktop-sm {
+				margin-bottom: 10px;
 			}
-			@include mobile{
+
+			@include mobile {
 				margin-right: 0;
 			}
 		}
 	}
 }
 
-.speakers{
+.speakers {
 	position: relative;
-	&.white{
-		.speaker-item{
+
+	&.white {
+		.speaker-item {
 			background: $light;
 			border: 1px solid $border-color;
-			&:hover{
+
+			&:hover {
 				@extend .shadow;
 			}
 		}
 	}
-	.speaker-item{
+
+	.speaker-item {
 		background: $gray;
 		padding: 7px;
 		margin-bottom: 30px;
-		.image{
+
+		.image {
 			margin-bottom: 16px;
 			position: relative;
 			overflow: hidden;
-			img{
+
+			img {
 				@include mobile {
 					width: 100% !important;
 				}
 			}
-			.primary-overlay{
+
+			.primary-overlay {
 				position: absolute;
 				top: 100%;
 				left: 0;
@@ -231,7 +279,8 @@
 				opacity: .85;
 				transition: .3s ease;
 			}
-			.socials{
+
+			.socials {
 				position: absolute;
 				top: 100%;
 				display: flex;
@@ -240,48 +289,57 @@
 				width: 100%;
 				height: 100%;
 				transition: .4s ease;
-				ul{
+
+				ul {
 					width: 50%;
-					@include large-desktop{
+
+					@include large-desktop {
 						width: 100%;
 						text-align: center;
 						padding: 0 20px;
 					}
+
 					// @include desktop {
 					// 	width: 61%;
 					// }
 					// @include mobile {
 					// 	width: 31%;
 					// }
-					li{
-						&.list-inline-item:not(:last-child){
+					li {
+						&.list-inline-item:not(:last-child) {
 							margin-right: 7px;
 							margin-bottom: 10px;
-							@include large-desktop{
+
+							@include large-desktop {
 								margin-right: 5px;
 								margin-left: 5px;
 							}
 						}
-						&.list-inline-item:last-child{
-							@include large-desktop{
+
+						&.list-inline-item:last-child {
+							@include large-desktop {
 								margin-right: 5px;
 								margin-left: 5px;
 							}
 						}
-						a{
+
+						a {
 							display: block;
 							height: 50px;
 							width: 50px;
 							text-align: center;
 							border: 1px solid $light;
-							i{
+
+							i {
 								font-size: .9375rem;
 								color: $light;
 								line-height: 50px;
 							}
-							&:hover{
+
+							&:hover {
 								background: $light;
-								i{
+
+								i {
 									color: $black;
 								}
 							}
@@ -289,28 +347,33 @@
 					}
 				}
 			}
-			&:hover{
-				.primary-overlay{
+
+			&:hover {
+				.primary-overlay {
 					top: 0;
 				}
-				.socials{
+
+				.socials {
 					top: 0;
 				}
 			}
 		}
-		.content{
-			h5{
-				a{
+
+		.content {
+			h5 {
+				a {
 					font-size: 22px;
 					color: $black;
 					font-weight: 400;
 					margin-bottom: 0;
-					&:hover{
+
+					&:hover {
 						color: $primary-color;
 					}
 				}
 			}
-			p{
+
+			p {
 				font-size: 0.875rem; //14px
 				margin-bottom: 5px;
 			}
@@ -318,19 +381,22 @@
 	}
 }
 
-.schedule{
-	.schedule-tab{
+.schedule {
+	.schedule-tab {
 		display: flex;
 		justify-content: center;
 		margin-top: 14px;
-		ul{
-			li.nav-item{
+
+		ul {
+			li.nav-item {
 				margin-right: 10px;
+
 				@include tablet {
 					width: 100%;
 					margin-bottom: 10px;
 				}
-				a{
+
+				a {
 					font-family: $secondary-font;
 					text-transform: uppercase;
 					font-size: 1.5rem; //24px
@@ -340,7 +406,8 @@
 					border-radius: 0;
 					border: 1px solid $border-color;
 					padding: 20px 30px;
-					span{
+
+					span {
 						margin-top: 2px;
 						font-family: $primary-font;
 						display: block;
@@ -348,14 +415,17 @@
 						color: $text-color;
 						font-weight: 400;
 					}
-					&.active{
+
+					&.active {
 						background: $primary-color;
 						color: $light;
 						position: relative;
-						span{
+
+						span {
 							color: $light;
 						}
-						&:after{
+
+						&:after {
 							content: '';
 							position: absolute;
 							left: 0;
@@ -365,6 +435,7 @@
 							border-style: solid;
 							border-width: 0 20px 20px 0;
 							border-color: transparent $primary-color transparent transparent;
+
 							@include tablet {
 								content: none;
 							}
@@ -374,101 +445,128 @@
 			}
 		}
 	}
-	.schedule-contents{
+
+	.schedule-contents {
 		margin-top: 30px;
 		margin-bottom: 30px;
 		padding: 30px;
-		.schedule-item{
-			ul{
-				li{
+
+		.schedule-item {
+			ul {
+				li {
 					list-style: none;
-					div{
+
+					div {
 						display: inline-block;
 					}
-					.time{
+
+					.time {
 						width: 20%;
+
 						@include tablet {
 							width: 37%;
 						}
+
 						@include mobile {
 							width: 48%;
 						}
 					}
-					.speaker{
+
+					.speaker {
 						width: 30%;
+
 						@include desktop-sm {
 							width: 50%;
 						}
+
 						@include tablet {
 							width: 60%;
 						}
+
 						@include mobile {
 							width: 50%;
 						}
+
 						img {
 							@include mobile {
 								display: none;
 							}
 						}
 					}
-					.subject{
+
+					.subject {
 						width: 30%;
+
 						@include large-desktop {
 							display: none;
 						}
 					}
-					.venue{
+
+					.venue {
 						@include tablet {
 							display: none;
 						}
 					}
 				}
+
 				margin-bottom: 0;
 			}
-			li.headings{
+
+			li.headings {
 				padding: 22px 40px;
 				background: $primary-color;
-				div{
+
+				div {
 					color: $light;
 					text-transform: uppercase;
 					font-family: $secondary-font;
 				}
 			}
-			li.schedule-details{
+
+			li.schedule-details {
 				border-bottom: 1px solid;
 				border-left: 1px solid;
 				border-right: 1px solid;
 				border-color: $border-color;
-				.block{
+
+				.block {
 					padding: 10px 40px;
 					background: $light;
 					width: 100%;
 					transition: .2s ease-in;
-					div{
+
+					div {
 						color: $black;
 						font-family: $secondary-font;
-						i{
+
+						i {
 							font-size: 1.1875em;
 							color: #c7c8c9;
 						}
-						img{
+
+						img {
 							border-radius: 100%;
 						}
-						span.time{
+
+						span.time {
 							margin-left: 5px;
 						}
-						span.name{
+
+						span.name {
 							margin-left: 20px;
 							transition: .2s ease-in;
+
 							@include mobile {
 								margin-left: 0;
 							}
 						}
 					}
-					&:hover{
+
+					&:hover {
 						box-shadow: 0px 0px 30px 0px rgba(11, 29, 66, 0.15);
 						transform: scale(1.01);
-						span.name{
+
+						span.name {
 							color: $primary-color;
 						}
 					}
@@ -476,28 +574,34 @@
 			}
 		}
 	}
-	.download-button{
+
+	.download-button {
 		padding-top: 40px;
 		margin-bottom: 30px;
 	}
-	&.two{
-		.schedule-tab{
+
+	&.two {
+		.schedule-tab {
 			display: flex;
 			justify-content: center;
 			margin-top: 30px;
-			ul{
-				li.nav-item{
+
+			ul {
+				li.nav-item {
 					margin-right: 0;
 					margin-bottom: 10px;
+
 					@include desktop-sm {
 						margin-right: 10px;
 					}
+
 					@include tablet {
 						width: 100%;
 						margin-bottom: 10px;
 						margin-right: 0;
 					}
-					a{
+
+					a {
 						font-family: $secondary-font;
 						text-transform: uppercase;
 						font-size: 20px; //24px
@@ -507,7 +611,8 @@
 						border-radius: 0;
 						border: 1px solid $border-color;
 						padding: 20px 30px;
-						span{
+
+						span {
 							margin-top: 2px;
 							font-family: $primary-font;
 							display: block;
@@ -515,18 +620,21 @@
 							color: $text-color;
 							font-weight: 400;
 						}
-						&.active{
+
+						&.active {
 							background: $primary-color;
 							color: $light;
 							position: relative;
-							span{
+
+							span {
 								color: $light;
 							}
-							&:after{
+
+							&:after {
 								content: '';
 								position: absolute;
 								left: 100%;
-								right:0;
+								right: 0;
 								bottom: 0;
 								top: 50%;
 								transform: translate(0, -50%);
@@ -535,6 +643,7 @@
 								border-style: solid;
 								border-width: 10px 0 10px 10px;
 								border-color: transparent transparent transparent $primary-color;
+
 								@include desktop-sm {
 									content: none;
 								}
@@ -544,106 +653,135 @@
 				}
 			}
 		}
-		.schedule-contents{
+
+		.schedule-contents {
 			margin-top: 30px;
 			margin-bottom: 30px;
 			padding: 0;
 			@extend .shadow;
-			.schedule-item{
-				ul{
-					li{
+
+			.schedule-item {
+				ul {
+					li {
 						list-style: none;
-						div{
+
+						div {
 							display: inline-block;
 						}
-						.time{
+
+						.time {
 							width: 20%;
+
 							@include tablet {
 								width: 37%;
 							}
+
 							@include mobile {
 								width: 48%;
 							}
 						}
-						.speaker{
+
+						.speaker {
 							width: 30%;
+
 							@include desktop-sm {
 								width: 50%;
 							}
+
 							@include tablet {
 								width: 60%;
 							}
+
 							@include mobile {
 								width: 50%;
 							}
 						}
-						.subject{
+
+						.subject {
 							width: 30%;
+
 							@include large-desktop {
 								display: none;
 							}
 						}
-						.venue{
+
+						.venue {
 							width: 18.6%;
+
 							@include tablet {
 								display: none;
 							}
 						}
 					}
+
 					margin-bottom: 0;
 				}
-				li.headings{
+
+				li.headings {
 					padding: 25px 0;
 					background: $primary-color;
-					div{
+
+					div {
 						color: $light;
 						text-transform: uppercase;
 						font-family: $secondary-font;
 					}
 				}
-				li.schedule-details{
-					&:not(:last-child){
+
+				li.schedule-details {
+					&:not(:last-child) {
 						border-bottom: 1px solid $border-color;
 					}
-					.block{
+
+					.block {
 						text-align: center;
 						padding: 0;
 						background: $light;
 						width: 100%;
 						transition: .2s ease-in;
-						div{
+
+						div {
 							padding-top: 25px;
 							padding-bottom: 25px;
 							color: $black;
 							font-family: $secondary-font;
-							i{
+
+							i {
 								font-size: 1.1875em;
 								color: #c7c8c9;
 							}
-							img{
+
+							img {
 								border-radius: 100%;
 							}
-							span.time{
+
+							span.time {
 								margin-left: 0px;
 							}
-							span.name{
+
+							span.name {
 								margin-left: 0px;
 								transition: .2s ease-in;
+
 								@include mobile {
 									margin-left: 0;
 								}
 							}
-							&:not(:last-child){
+
+							&:not(:last-child) {
 								border-right: 1px solid $border-color;
 							}
 						}
-						&:not(:last-child){
+
+						&:not(:last-child) {
 							border-bottom: 1px solid $border-color;
 						}
-						&:hover{
+
+						&:hover {
 							box-shadow: none;
 							transform: scale(1);
-							span.name{
+
+							span.name {
 								color: $primary-color;
 							}
 						}
@@ -654,35 +792,43 @@
 	}
 }
 
-.ticket-feature{
+.ticket-feature {
 	overflow: hidden;
-	.block{
+
+	.block {
 		position: relative;
 		padding-top: 150px;
 		padding-bottom: 110px;
-		.section-title, a{
+
+		.section-title,
+		a {
 			position: relative;
 		}
-		.section-title{
-			h3{
+
+		.section-title {
+			h3 {
 				font-weight: 500;
 			}
 		}
-		.timer{
+
+		.timer {
 			position: relative;
 			margin-top: 60px;
 			margin-bottom: 35px;
+
 			.syotimer-cell {
-		        margin-right: 25px;
-		        margin-bottom: 33px;
-		        display:inline-block;
-		        @include mobile {
-		        	margin-right: 10px;
-		        	margin-bottom: 20px;
-		        }
-		        .syotimer-cell__value {
-		        	min-width: 80px;
-		        	font-family: $secondary-font;
+				margin-right: 25px;
+				margin-bottom: 33px;
+				display: inline-block;
+
+				@include mobile {
+					margin-right: 10px;
+					margin-bottom: 20px;
+				}
+
+				.syotimer-cell__value {
+					min-width: 80px;
+					font-family: $secondary-font;
 					font-size: 35px;
 					height: 100px;
 					width: 100px;
@@ -691,73 +837,88 @@
 					position: relative;
 					font-weight: bold;
 					color: $light;
-					border: 2px solid rgba(255,255,255, .35);
+					border: 2px solid rgba(255, 255, 255, .35);
 					background-clip: content-box;
-					background: rgba(255,255,255, .26);
+					background: rgba(255, 255, 255, .26);
 					margin-bottom: 8px;
 					border-radius: 100%;
-			        @include mobile {
+
+					@include mobile {
 						font-size: 30px;
 						height: 80px;
 						width: 80px;
 						line-height: 80px;
-			        }
-			        // box-shadow: 0px 0px 0px 4px green;
-		        }
-		        .syotimer-cell__unit {
-		        	text-align: center;
+					}
+
+					// box-shadow: 0px 0px 0px 4px green;
+				}
+
+				.syotimer-cell__unit {
+					text-align: center;
 					font-size: 1rem;
 					text-transform: lowercase;
-					font-weight:normal;
+					font-weight: normal;
 					color: $light;
 					font-family: $secondary-font;
-		        }
-		      }
+				}
+			}
 		}
 	}
-	.block-2{
+
+	.block-2 {
 		position: relative;
 		padding: 150px 10%;
 		height: 100%;
 		background: $primary-color;
-		@include mobile{
+
+		@include mobile {
 			padding: 50px 20px;
 		}
-		[class*=col-]{
-			&:first-child{
+
+		[class*=col-] {
+			&:first-child {
 				border-right: 1px solid #fc9552;
 				border-bottom: 1px solid #fc9552;
 			}
-			&:nth-child(2){
+
+			&:nth-child(2) {
 				border-bottom: 1px solid #fc9552;
 			}
-			&:nth-child(3){
+
+			&:nth-child(3) {
 				border-right: 1px solid #fc9552;
 			}
 		}
-		.service-item{
+
+		.service-item {
 			padding: 30px;
 			text-align: center;
-			i, h5{
+
+			i,
+			h5 {
 				color: $light;
 			}
-			i{
-				font-size: 3.25rem;//52px
+
+			i {
+				font-size: 3.25rem; //52px
 				margin-bottom: 20px;
 			}
-			h5{
+
+			h5 {
 				font-family: $primary-font;
 				font-weight: 400;
 				text-transform: uppercase;
-				@include mobile{
+
+				@include mobile {
 					font-size: 1rem;
 				}
 			}
 		}
-		&:after{
+
+		&:after {
 			content: '';
 			position: absolute;
-			right:100%;
+			right: 100%;
 			bottom: 0;
 			top: 0;
 			width: 0;
@@ -765,6 +926,7 @@
 			border-style: solid;
 			border-width: 0 0 1000px 300px;
 			border-color: transparent transparent $primary-color transparent;
+
 			@include large-desktop {
 				content: none;
 			}
@@ -772,170 +934,212 @@
 	}
 }
 
-.registration{
+.registration {
 	overflow: hidden;
-	.service-block{
+
+	.service-block {
 		position: relative;
 		padding: 120px 10%;
-		[class*=col-]{
-			&:first-child{
+
+		[class*=col-] {
+			&:first-child {
 				border-right: 1px solid #f69351;
 				border-bottom: 1px solid #f69351;
 			}
-			&:nth-child(2){
+
+			&:nth-child(2) {
 				border-bottom: 1px solid #f69351;
 			}
-			&:nth-child(3){
+
+			&:nth-child(3) {
 				border-right: 1px solid #f69351;
 			}
 		}
-		.service-item{
+
+		.service-item {
 			padding: 30px;
 			text-align: center;
-			i, h5{
+
+			i,
+			h5 {
 				color: $light;
 			}
-			i{
-				font-size: 3.25rem;//52px
+
+			i {
+				font-size: 3.25rem; //52px
 				margin-bottom: 20px;
 			}
-			h5{
+
+			h5 {
 				font-family: $primary-font;
 				font-weight: 400;
 				text-transform: uppercase;
-				@include mobile{
+
+				@include mobile {
 					font-size: 12px;
 				}
 			}
 		}
 	}
-	.registration-block{
+
+	.registration-block {
 		position: relative;
 		height: 100%;
 		padding: 120px 10%;
-		.block{
+
+		.block {
 			position: relative;
 			z-index: 9;
-			.title{
-				h3{
+
+			.title {
+				h3 {
 					color: $light;
 					font-weight: 500;
 					margin-bottom: 10px;
 				}
-				p{
+
+				p {
 					color: darken($light, 30%);
 					line-height: 1;
 				}
+
 				margin-bottom: 35px;
 			}
 		}
 	}
 }
 
-.pricing{
-	.pricing-item{
+.pricing {
+	.pricing-item {
 		border: 1px solid $border-color;
+
 		@include desktop-sm {
 			margin-bottom: 30px;
 		}
-		.pricing-heading{
+
+		.pricing-heading {
 			padding: 20px 40px 30px 40px;
 			background: $light-gray;
 			border-bottom: 1px solid $border-color;
-			.title{
-				h6{
+
+			.title {
+				h6 {
 					text-transform: uppercase;
 					font-weight: 400;
 					line-height: 50px;
 					border-bottom: 1px solid $border-color;
 				}
 			}
-			.price{
+
+			.price {
 				margin-top: 28px;
-				h2{
+
+				h2 {
 					font-size: 3.625rem;
 					font-weight: 400;
-					span{
+
+					span {
 						font-size: 1.5625rem;
 					}
+
 					margin-bottom: 0px;
 				}
 			}
 		}
-		.pricing-body{
+
+		.pricing-body {
 			padding: 45px 40px;
-			ul.feature-list{
-				li{
+
+			ul.feature-list {
+				li {
 					list-style: none;
-					p{
-						span{
+
+					p {
+						span {
 							margin-right: 15px;
-							&.available{
+
+							&.available {
 								color: $primary-color;
 							}
-							&.unavailable{
+
+							&.unavailable {
 								color: #d2d2d2;
 							}
 						}
 					}
-					&:not(:last-child){
+
+					&:not(:last-child) {
 						margin-bottom: 15px;
 					}
 				}
 			}
 		}
-		.pricing-footer{
+
+		.pricing-footer {
 			padding-bottom: 40px;
 		}
 
-		&.featured{
+		&.featured {
 			border: none;
 			box-shadow: 0px 0px 30px 0px rgba(11, 29, 66, 0.15);
-			.pricing-heading{
+
+			.pricing-heading {
 				background: $primary-color;
 				border-bottom: 1px solid $primary-color;
-				.title{
-					h6{
+
+				.title {
+					h6 {
 						color: $light;
 						border-bottom: 1px solid #f69351;
 					}
 				}
-				.price{
+
+				.price {
 					margin-top: 28px;
-					h2{
+
+					h2 {
 						color: $light;
 						font-size: 3.625rem;
-						span{
+
+						span {
 							font-size: 1.5625rem;
 						}
+
 						margin-bottom: 0px;
 					}
-					p{
+
+					p {
 						color: $light;
 					}
 				}
 			}
 		}
 	}
-	&.two{
-		.pricing-item{
+
+	&.two {
+		.pricing-item {
 			border: 1px solid $border-color;
 			overflow: hidden;
+
 			@include desktop-sm {
 				margin-bottom: 30px;
 			}
-			.pricing-heading{
+
+			.pricing-heading {
 				position: relative;
 				margin-bottom: 10px;
-				.title{
-					h6{
+
+				.title {
+					h6 {
 						position: relative;
 					}
 				}
-				.price{
+
+				.price {
 					position: relative;
 				}
-				&:before{
+
+				&:before {
 					content: '';
 					position: absolute;
 					bottom: -25%;
@@ -945,18 +1149,21 @@
 					border-style: solid;
 					border-width: 64px 500px 0 0;
 					border-color: $light-gray transparent transparent transparent;
-					@include desktop-sm{
+
+					@include desktop-sm {
 						content: none;
 					}
 				}
 			}
-			.pricing-body{
+
+			.pricing-body {
 				padding: 70px 40px 45px;
-				ul.feature-list{
-					li{
-						p{
-							span{
-								&.available{
+
+				ul.feature-list {
+					li {
+						p {
+							span {
+								&.available {
 									color: $primary-color;
 								}
 							}
@@ -965,9 +1172,9 @@
 				}
 			}
 
-			&.featured{
-				.pricing-heading{
-					&:before{
+			&.featured {
+				.pricing-heading {
+					&:before {
 						border-color: $primary-color transparent transparent transparent;
 					}
 				}
@@ -976,140 +1183,179 @@
 	}
 }
 
-.sponsors{
+.sponsors {
 	position: relative;
-	.sponsor-title{
+
+	.sponsor-title {
 		margin-top: 10px;
-		h5{
+
+		h5 {
 			color: $primary-color;
 		}
+
 		margin-bottom: 30px;
 	}
-	.block{
-		.list-inline-item:not(:last-child){
+
+	.block {
+		.list-inline-item:not(:last-child) {
 			margin-right: 15px;
-			@include desktop-sm{
+
+			@include desktop-sm {
 				margin-right: 7px;
 				margin-left: 7px;
 			}
 		}
-		.list-inline-item:last-child{
-			@include desktop-sm{
+
+		.list-inline-item:last-child {
+			@include desktop-sm {
 				margin-right: 7px;
 				margin-left: 7px;
 			}
 		}
-		.image-block{
+
+		.image-block {
 			padding: 45px 0;
 			background: transparent;
 			width: auto;
 			cursor: pointer;
 			transition: all .3s ease;
 			border: 1px solid transparent;
-			img{
+
+			img {
 				height: 70px;
 				padding-right: 15px;
 				padding-left: 15px;
 			}
+
 			margin-bottom: 10px;
-			&:hover{
+
+			&:hover {
 				@extend .shadow;
 				border: 1px solid $primary-color;
 			}
 		}
+
 		margin-bottom: 40px;
 	}
-	.sponsor-btn{
+
+	.sponsor-btn {
 		margin-top: 10px;
 		margin-bottom: 30px;
 	}
 }
 
 // Google map
-.map{
+.map {
 	position: relative;
-	#map_canvas{
-		height:480px;
+
+	#map_canvas {
+		height: 480px;
 		color: white;
 	}
-	.address-block{
+
+	.address-block {
 		position: absolute;
 		padding: 45px 50px 50px 50px;
 		top: 80px;
 		left: 10%;
+
 		@include mobile {
 			display: none;
 		}
+
 		background: $primary-color;
-		h4,li{
+
+		h4,
+		li {
 			color: $light;
 			margin-bottom: 20px;
 		}
-		h4{
+
+		h4 {
 			font-size: 1.5rem;
 			font-weight: 400;
 		}
-		ul.address-list{
-			li{
+
+		ul.address-list {
+			li {
 				list-style: none;
-				i{
+
+				i {
 					font-size: 1.125rem;
 				}
-				span{
+
+				span {
 					margin-left: 15px;
 				}
+
 				margin-bottom: 10px;
 			}
-			a{
-        color:white;
-        &:hover{
-          color:black;
-        }
-      }
+
+			a {
+				color: white;
+
+				&:hover {
+					color: black;
+				}
+			}
 		}
-		a{
+
+		a {
 			margin-top: 35px;
 		}
 	}
-	&.new{
+
+	&.new {
 		overflow: hidden;
-		#map{
+
+		#map {
 			height: 640px;
 		}
-		.address-block{
+
+		.address-block {
 			// right: 10%;
 			left: 60%;
-			@include desktop-sm{
+
+			@include desktop-sm {
 				left: 52%;
 			}
-			@include tablet{
+
+			@include tablet {
 				left: 5%;
 			}
 		}
-		.register{
+
+		.register {
 			width: 50%;
 			position: absolute;
 			top: 0;
 			left: 0;
 			overflow: hidden;
+
 			@include tablet {
 				width: 100%;
 				position: relative;
 			}
-			.block{
+
+			.block {
 				padding: 130px 10%;
-				.title{
+
+				.title {
 					position: relative;
 					margin-bottom: 65px;
-					h3{
+
+					h3 {
 						color: $light;
 						font-weight: 400;
 					}
-					p{
+
+					p {
 						color: $light;
 					}
 				}
-				.form-control,button{
+
+				.form-control,
+				button {
 					margin-bottom: 40px;
 				}
 			}
@@ -1117,30 +1363,37 @@
 	}
 }
 
-.feature{
-	.feature-content{
-		h2, p{
+.feature {
+	.feature-content {
+
+		h2,
+		p {
 			margin-bottom: 25px;
+
 			@include tablet {
 				text-align: center;
 			}
 		}
 	}
-	.testimonial{
+
+	.testimonial {
 		@include tablet {
 			text-align: center;
 		}
-		p{
+
+		p {
 			font-family: $secondary-font;
 			margin-bottom: 10px;
 			font-style: italic;
 			color: #242424;
 		}
-		ul.meta{
-			li{
+
+		ul.meta {
+			li {
 				font-size: 12px;
 				margin-right: 10px;
-				img{
+
+				img {
 					height: 40px;
 					width: 40px;
 					border-radius: 100%;
@@ -1151,128 +1404,149 @@
 }
 
 // App Features
-.app-features{
-	.app-feature{
+.app-features {
+	.app-feature {
 		@include mobile {
 			margin-bottom: 30px;
 		}
 	}
-	.app-explore{
+
+	.app-explore {
 		display: flex;
-        justify-content: center !important;
-	    margin-bottom: 40px;
+		justify-content: center !important;
+		margin-bottom: 40px;
 	}
 }
 
-.banner-full{
-	.image{
+.banner-full {
+	.image {
 		display: flex;
-        justify-content: center;
-		img{
+		justify-content: center;
+
+		img {
 			height: 625px;
 		}
+
 		@include tablet {
 			margin-bottom: 30px;
 		}
 	}
-	.block{
+
+	.block {
 		@include tablet {
 			text-align: center;
 		}
-		.logo{
+
+		.logo {
 			margin-bottom: 40px;
 		}
-		h1{
+
+		h1 {
 			margin-bottom: 40px;
 		}
-		p{
+
+		p {
 			font-size: 20px;
 			margin-bottom: 50px;
 		}
-		.app{
+
+		.app {
 			margin-bottom: 20px;
 		}
 	}
 }
 
-.video-promo{
+.video-promo {
 	padding: 150px 0;
-	.content-block{
+
+	.content-block {
 		width: 60%;
 		margin: 0 auto;
 		text-align: center;
-		h2{
+
+		h2 {
 			font-size: 30px;
 			color: $light;
 		}
-		p{
+
+		p {
 			margin-bottom: 30px;
 		}
-		a{
-			i.video{
+
+		a {
+			i.video {
 				height: 125px;
-			    width: 125px;
-			    background: $primary-color;
-			    display: inline-block;
-			    font-size: 40px;
-			    color: $light;
-			    text-align: center;
-			    line-height: 125px;
-			    border-radius: 100%;
+				width: 125px;
+				background: $primary-color;
+				display: inline-block;
+				font-size: 40px;
+				color: $light;
+				text-align: center;
+				line-height: 125px;
+				border-radius: 100%;
 			}
-			&:focus{
+
+			&:focus {
 				outline: 0;
 			}
 		}
 	}
 }
 
-.testimonial{
-	.testimonial-slider{
-		.item{
+.testimonial {
+	.testimonial-slider {
+		.item {
 			padding-bottom: 10px;
-			.block{
+
+			.block {
 				padding: 40px;
 				text-align: center;
 				margin: 10px;
-		        border-radius: 5px;
-				.image{
+				border-radius: 5px;
+
+				.image {
 					margin-top: 30px;
 					margin-bottom: 5px;
 					width: 100%;
 					display: flex;
-			        justify-content: center;
+					justify-content: center;
+
 					@include tablet {
-				        flex-grow: 1;
+						flex-grow: 1;
 					}
-					img{
+
+					img {
 						height: 40px;
 						width: 40px;
-				        border-radius: 100%;
+						border-radius: 100%;
 					}
 				}
-				p{
+
+				p {
 					font-family: $secondary-font;
 					font-style: italic;
 					color: #888888;
 				}
-				cite{
+
+				cite {
 					font-style: normal;
 					font-size: 14px;
 					color: #161616;
 				}
 			}
 		}
+
 		// Owl dot Active color overide
-		.owl-dots{
-			.owl-dot{
-				&:hover{
-					span{
+		.owl-dots {
+			.owl-dot {
+				&:hover {
+					span {
 						background: $primary-color;
 					}
 				}
-				&.active{
-					span{
+
+				&.active {
+					span {
 						background: $primary-color;
 					}
 				}


### PR DESCRIPTION
Hello! 

I noticed that the primary colors were carried over from the 2024 event, and thought that perhaps changing them to match the 2025 logo for Mostar might be a nice change to give the event it's own unique look and feel?

Here's what it looks like:

<img width="1708" alt="Screenshot 2025-02-12 at 19 23 43" src="https://github.com/user-attachments/assets/c8093c41-836c-42ca-b609-3b322e2222db" />
<img width="1708" alt="Screenshot 2025-02-12 at 19 23 48" src="https://github.com/user-attachments/assets/1cf02329-cff7-4dc2-99ef-68f04c970e65" />
<img width="1708" alt="Screenshot 2025-02-12 at 19 23 52" src="https://github.com/user-attachments/assets/2c91f0fe-15a1-4648-8d04-c58907f027bd" />

Also fixes the footer color to be white so it can read.

Let me know what you think :) 

Thanks! 
