### PR TITLE
remove maximum-scale=1 from HTML header

### DIFF
--- a/themes/eventre-hugo/layouts/partials/head.html
+++ b/themes/eventre-hugo/layouts/partials/head.html
@@ -12,7 +12,7 @@ AUTHOR WEBSITE: https://themefisher.com
   <title>{{ .Title }}</title>
 
   {{ "<!-- mobile responsive meta -->" | safeHTML }}
-  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="description" content="{{ with .Params.Description }}{{ . }}{{ else }}{{ with site.Params.description }}{{ . }}{{ end }}{{ end }}">
   {{ with site.Params.author }}<meta name="author" content="{{ . }}">{{ end }}
 


### PR DESCRIPTION
As explained in https://lukeplant.me.uk/blog/posts/you-can-stop-using-user-scalable-no-and-maximum-scale-1-in-viewport-meta-tags-now/

"Why should you remove these properties? Because they’re bad for accessibility — they stop users on many mobile devices (mostly Android) from being able to zoom in and view things that would be too small otherwise. This doesn’t just affect people with impaired vision — as a fully sighted person I often find web pages where there are graphics with text and other details that are too small when using a mobile phone, and then I find I can’t zoom in either.

Who says so? The A11Y Project says [“Never use maximum-scale=1”](https://www.a11yproject.com/posts/never-use-maximum-scale/), and [MDN also agree](https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag)"